### PR TITLE
remove extra line on auto format

### DIFF
--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -60,6 +60,7 @@ function! s:JSFormat()
     " NO ERROR
     try | silent undojoin | catch | endtry
     silent execute "%!" . command
+    $delete
 
     " only clear quickfix if it was previously set, this prevents closing
     " other quickfixs


### PR DESCRIPTION
Reapplying patch from github.com/mephux/vim-jsfmt/issues/2