### PR TITLE
remove $delete line

### DIFF
--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -60,7 +60,6 @@ function! s:JSFormat()
     " NO ERROR
     try | silent undojoin | catch | endtry
     silent execute "%!" . command
-    $delete
 
     " only clear quickfix if it was previously set, this prevents closing
     " other quickfixs


### PR DESCRIPTION
Annoying of jsfmt that this keeps coming up as it seems to matter for different version of jsfmt. Using the latest jsfmt 0.4.1 the $delete line needs to be removed again as it removes the last line of your current file on save.