### PR TITLE
Fix error regex and implement g:js_fmt_fail_silently

### DIFF
--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -45,7 +45,8 @@ function! s:JSFormat()
     return
   endif
 
-  let tokens = matchlist(out, '{ [Error: Line \(\d\+\): \(.\+\)\] index: \(\d\+\), lineNumber: \(\d\+\), column: \(\d\+\) }')
+  "let tokens = matchlist(out, '{ [Error: Line \(\d\+\): \(.\+\)\]\s\+index:\s\+\(\d\+\),\s\+lineNumber:\s\+\(\d\+\),\s\+column:\s\+\(\d\+\)')
+  let tokens = matchlist(out, '{ [Error: Line \(\d\+\): \(.\+\)\]\n\s\+index:\s\+\(\d\+\),\n\s\+lineNumber:\s\+\(\d\+\),\n\s\+column:\s\+\(\d\+\)')
 
   let errors = []
 

--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -71,13 +71,13 @@ function! s:JSFormat()
     endif
   endif
 
-  if !empty(errors)
+  if !empty(errors) && !g:js_fmt_fail_silently
     call setqflist(errors, 'r')
     echohl Error | echomsg "jsfmt returned error" | echohl None
-  endif
 
-  let s:got_fmt_error = 1
-  cwindow
+      let s:got_fmt_error = 1
+      cwindow
+  endif
 
   call delete(l:tmpname)
   call winrestview(l:curw)


### PR DESCRIPTION
possibly fixes #7, the behavior i'm getting is that the buffer contents is replaced by the error output because the error regex failed to spot how jsfmt is printing it